### PR TITLE
Updated StencilSwiftKit to fix a compilation issue with Swift 4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.21.0"),
         .package(url: "https://github.com/kylef/Commander.git", from: "0.6.0"),
         .package(url: "https://github.com/kylef/Stencil.git", from: "0.11.0"),
-        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.4.0")
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.5.0")
     ],
     targets: [
         .target(name: "WeaverCodeGen", dependencies: ["SourceKittenFramework", "Stencil", "StencilSwiftKit"]),

--- a/Sources/WeaverCodeGen/Linker.swift
+++ b/Sources/WeaverCodeGen/Linker.swift
@@ -185,7 +185,7 @@ extension Dependency {
     }
     
     var scope: Scope? {
-        return !isReference ? configuration.scope : nil
+        return nil
     }
     
     var configuration: DependencyConfiguration {
@@ -194,6 +194,17 @@ extension Dependency {
     
     var isReference: Bool {
         return self is Reference
+    }
+    
+    private var isRegistration: Bool {
+        return self is Registration
+    }
+}
+
+extension Dependency where Self: Registration {
+
+    var scope: Scope? {
+        return configuration.scope
     }
 }
 


### PR DESCRIPTION
This should fix the compilation issue ` Compiler is unable to type-check this expression` error with Swift 4.2 (#57)

Before I merge this, @ferologics could you try to see if that fixed the issue please? 