### PR TITLE
Fix grep error for empty dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/scribd/Meta.git",
         "state": {
           "branch": "master",
-          "revision": "94685cb2252a7eb5caa0f74a440f5d130595733b",
+          "revision": "a955d8dfbaaf6416922967d190580ea5a4571288",
           "version": null
         }
       },
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "6abeb3f5c03beba2b9e4dbe20886e773b5b629b6",
-          "version": "8.0.4"
+          "revision": "b02b00b30b6353632aa4a5fb6124f8147f7140c0",
+          "version": "8.0.5"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "356551fc513eb12ed779bb369f79cf86a3a01599",
-          "version": "0.27.0"
+          "revision": "77a4dbbb477a8110eb8765e3c44c70fb4929098f",
+          "version": "0.29.0"
         }
       },
       {

--- a/Sources/WeaverCodeGen/Lexer.swift
+++ b/Sources/WeaverCodeGen/Lexer.swift
@@ -135,7 +135,7 @@ private extension Lexer {
                 return nil
             }
 
-            guard let nextLine = findNextLine(after: currentLine, containing: syntaxToken.offset) else {
+            guard let nextLine = findNextLine(after: currentLine, containing: syntaxToken.offset.value) else {
                 return nil
             }
             currentLine = nextLine
@@ -144,8 +144,8 @@ private extension Lexer {
 
             do {
                 guard let token = try TokenBuilder.makeAnnotationToken(string: content,
-                                                                       offset: syntaxToken.offset,
-                                                                       length: syntaxToken.length,
+                                                                       offset: syntaxToken.offset.value,
+                                                                       length: syntaxToken.length.value,
                                                                        line: currentLine) else {
                     return nil
                 }

--- a/Sources/WeaverCommand/Configuration.swift
+++ b/Sources/WeaverCommand/Configuration.swift
@@ -218,7 +218,13 @@ extension Configuration {
             "-e", Configuration.propertyWrapperRegex,
             directory.absolute().string
         ]
-        return try shellOut(to: "grep", arguments: grepArguments)
+        // if there are no files matching the pattern
+        // command grep return exit 1, and ShellOut throws an exception with empty message
+        guard let grepResult = try? shellOut(to: "grep", arguments: grepArguments) else {
+            return []
+        }
+
+        return grepResult
             .split(separator: "\n")
             .lazy
             .map { Path(String($0)) }

--- a/Sources/WeaverCommand/Configuration.swift
+++ b/Sources/WeaverCommand/Configuration.swift
@@ -196,22 +196,22 @@ extension Configuration {
     func inputPaths() throws -> [Path]  {
         var inputPaths = Set<Path>()
         
-        inputPaths.formUnion(try inputPathStrings
+        inputPaths.formUnion(inputPathStrings
             .lazy
             .map { self.projectPath + $0 }
-            .flatMap { $0.isFile ? [$0] : try self.recursiveFilesByPattren(fromDirectory: $0) }
+            .flatMap { $0.isFile ? [$0] : self.recursiveFilesByPattern(fromDirectory: $0) }
             .filter { $0.exists && $0.isFile && $0.extension == "swift" })
 
         inputPaths.subtract(try ignoredPathStrings
             .lazy
             .map { self.projectPath + $0 }
-            .flatMap { $0.isFile ? [$0] : try self.files(fromDirectory: $0) }
+            .flatMap { $0.isFile ? [$0] : try files(fromDirectory: $0) }
             .filter { $0.extension == "swift" })
         
         return inputPaths.sorted()
     }
 
-    private func recursiveFilesByPattren(fromDirectory directory: Path) throws -> [Path] {
+    private func recursiveFilesByPattern(fromDirectory directory: Path) -> [Path] {
         let grepArguments = [
             "-lR",
             "-e", Configuration.annotationRegex,

--- a/Sources/WeaverCommand/Configuration.swift
+++ b/Sources/WeaverCommand/Configuration.swift
@@ -226,7 +226,6 @@ extension Configuration {
 
         return grepResult
             .split(separator: "\n")
-            .lazy
             .map { Path(String($0)) }
     }
 

--- a/Sources/WeaverCommand/Configuration.swift
+++ b/Sources/WeaverCommand/Configuration.swift
@@ -199,19 +199,19 @@ extension Configuration {
         inputPaths.formUnion(inputPathStrings
             .lazy
             .map { self.projectPath + $0 }
-            .flatMap { $0.isFile ? [$0] : self.recursiveFilesByPattern(fromDirectory: $0) }
+            .flatMap { $0.isFile ? [$0] : self.recursivePathsByPattern(fromDirectory: $0) }
             .filter { $0.exists && $0.isFile && $0.extension == "swift" })
 
         inputPaths.subtract(try ignoredPathStrings
             .lazy
             .map { self.projectPath + $0 }
-            .flatMap { $0.isFile ? [$0] : try files(fromDirectory: $0) }
+            .flatMap { $0.isFile ? [$0] : try paths(fromDirectory: $0) }
             .filter { $0.extension == "swift" })
         
         return inputPaths.sorted()
     }
 
-    private func recursiveFilesByPattern(fromDirectory directory: Path) -> [Path] {
+    private func recursivePathsByPattern(fromDirectory directory: Path) -> [Path] {
         let grepArguments = [
             "-lR",
             "-e", Configuration.annotationRegex,
@@ -229,7 +229,7 @@ extension Configuration {
             .map { Path(String($0)) }
     }
 
-    private func files(fromDirectory directory: Path) throws -> [Path] {
+    private func paths(fromDirectory directory: Path) throws -> [Path] {
         recursive ? try directory.recursiveChildren() : try directory.children()
     }
 }


### PR DESCRIPTION
Hello! Thanks for the cool tool. I prepared a small pull request with improvement.

Motivation: if I didn’t register or add any dependencies, now I get the error of the `weaver swift` command. In this case, I want to get the generated file with basic entities, for example `@Weaver`, so that you can use them