### PR TITLE
Replace static DependencyContainer validation with a trace through the entire runtime instantiation of the tree. 

### DIFF
--- a/Sources/WeaverCodeGen/RuntimeTreeInspector.swift
+++ b/Sources/WeaverCodeGen/RuntimeTreeInspector.swift
@@ -1,0 +1,185 @@
+//
+//  RuntimeTreeInspector.swift
+//  WeaverCodeGen
+//
+//  Created by Stephane Magne on 12/14/21.
+//
+
+import Foundation
+
+// MARK: - RuntimeTreeInspector
+
+public final class RuntimeTreeInspector {
+
+    private let rootNode: TreeNode
+
+    init(rootContainer: DependencyContainer,
+         dependencyGraph: DependencyGraph) throws {
+        self.rootNode = try TreeNode(rootContainer: rootContainer,
+                                     dependencyGraph: dependencyGraph)
+    }
+
+    public func validate() throws {
+        try validate(node: rootNode)
+    }
+
+    private func validate(node: TreeNode?) throws {
+        guard let node = node else { return }
+
+        for dependency in node.inspectingContainer.dependencies.orderedValues {
+            try validateConfiguration(of: dependency, node: node)
+        }
+
+        try validate(node: node.next())
+    }
+}
+
+// MARK: - Configuration check
+
+private extension RuntimeTreeInspector {
+
+    func validateConfiguration(of dependency: Dependency, node: TreeNode) throws {
+        switch dependency.configuration.scope {
+        case .container where dependency.kind.isResolvable:
+            let container = try node.dependencyGraph.dependencyContainer(for: dependency)
+            if let historyRecord = containerDependencyError(container, dependency, node) {
+                throw InspectorError.invalidDependencyGraph(dependency, underlyingError:.unresolvableDependency(history: historyRecord))
+            }
+        case .weak:
+            if dependency.kind == .parameter && dependency.type.anyType.isOptional == false {
+                throw InspectorError.weakParameterHasToBeOptional(dependency)
+            }
+        case .lazy,
+             .transient,
+             .container:
+            break
+        }
+    }
+
+    private func containerDependencyError(_ container: DependencyContainer, _ dependency: Dependency, _ node: TreeNode) -> [InspectorAnalysisHistoryRecord]? {
+
+        guard container.parameters.isEmpty == false else { return nil }
+
+        var stepCount = 0
+        var history: [InspectorAnalysisHistoryRecord] = [.triedToResolveDependencyInType(dependency, in: node.inspectingContainer, stepCount: stepCount)]
+
+        for parentContainer in node.dependencyChain.reversed() {
+            stepCount += 1
+            history.append(.triedToResolveDependencyInType(dependency, in: parentContainer, stepCount: stepCount))
+
+            guard let matchingDependency = parentContainer.dependencies[dependency.dependencyName] else { continue }
+
+            switch matchingDependency.kind {
+            case .parameter:
+                return nil
+            case .registration:
+                history.append(.invalidContainerScope(dependency))
+                return history
+            case .reference:
+                continue
+            }
+        }
+
+        if let rootContainer = node.dependencyChain.first {
+            history.append(.dependencyNotFound(dependency, in: rootContainer))
+        }
+        return history
+    }
+}
+
+// MARK: - Full Tree Iterator
+
+final class TreeNode: Sequence, IteratorProtocol {
+
+    let inspectingContainer: DependencyContainer
+
+    let dependencyChain: [DependencyContainer]
+
+    let dependencyGraph: DependencyGraph
+
+    let dependencyPointer: Dependency
+
+    convenience init(rootContainer: DependencyContainer,
+                     dependencyGraph: DependencyGraph) throws {
+        guard let firstDependency = rootContainer.dependencies.orderedValues.first else {
+            throw InspectorError.missingRootDependency
+        }
+
+        self.init(inspectingContainer: rootContainer,
+                  dependencyChain: [],
+                  dependencyGraph: dependencyGraph,
+                  dependencyPointer: firstDependency)
+    }
+
+    private init(inspectingContainer: DependencyContainer,
+                dependencyChain: [DependencyContainer],
+                dependencyGraph: DependencyGraph,
+                dependencyPointer: Dependency) {
+        self.inspectingContainer = inspectingContainer
+        self.dependencyChain = dependencyChain
+        self.dependencyGraph = dependencyGraph
+        self.dependencyPointer = dependencyPointer
+    }
+
+    /*
+     This will return the next node in the tree until the entire tree has been traversed.
+
+     The ordering will be, starting from the first dependency of the root node:
+     - The next node down the tree for the current dependency
+     - If none, then move to the next sibling dependency in the current node
+     - If none, then pop up to the parent node
+     */
+    func next() -> TreeNode? {
+
+        guard dependencyPointer.kind.isRegistration,
+              let nextContainer = try? dependencyGraph.dependencyContainer(for: dependencyPointer),
+              let firstNestedDependency = nextContainer.dependencies.orderedValues.first else {
+            return nextByIterating(after: dependencyPointer)
+        }
+
+        return TreeNode(inspectingContainer: nextContainer,
+                        dependencyChain: dependencyChain + [inspectingContainer],
+                        dependencyGraph: dependencyGraph,
+                        dependencyPointer: firstNestedDependency)
+    }
+
+    private func nextByIterating(after dependency: Dependency) -> TreeNode? {
+
+        let values = inspectingContainer.dependencies.orderedValues
+
+        guard let firstIndex = values.firstIndex(where: { $0 === dependency}) else {
+            return nextByPopping()
+        }
+
+        let nextIndex = values.index(after: firstIndex)
+        guard nextIndex < values.count else {
+            return nextByPopping()
+        }
+
+        let nextDependency: Dependency = values[nextIndex]
+        return TreeNode(inspectingContainer: inspectingContainer,
+                        dependencyChain: dependencyChain,
+                        dependencyGraph: dependencyGraph,
+                        dependencyPointer: nextDependency).next()
+    }
+
+    private func nextByPopping() -> TreeNode? {
+        guard let parentContainer: DependencyContainer = dependencyChain.last else {
+            return nil
+        }
+
+        guard let dependencyNames = parentContainer.dependencyNamesByConcreteType[inspectingContainer.type] else {
+            return nil
+        }
+
+        guard let dependencyName = dependencyNames.first(where: { parentContainer.dependencies[$0] != nil }),
+              let parentDependency = parentContainer.dependencies[dependencyName] else {
+            return nil
+        }
+
+        return TreeNode(inspectingContainer: parentContainer,
+                        dependencyChain: dependencyChain.dropLast(),
+                        dependencyGraph: dependencyGraph,
+                        dependencyPointer: parentDependency).nextByIterating(after: parentDependency)
+    }
+}

--- a/Tests/WeaverCodeGenTests/RuntimeTreeInspectorTests.swift
+++ b/Tests/WeaverCodeGenTests/RuntimeTreeInspectorTests.swift
@@ -1,0 +1,111 @@
+//
+//  RuntimeTreeInspectorTests.swift
+//  WeaverCodeGenTests
+//
+//  Created by Stephane Magne on 12/15/21.
+//
+
+import Foundation
+import XCTest
+import SourceKittenFramework
+
+@testable import WeaverCodeGen
+
+final class RuntimeTreeInspectorTests: XCTestCase {
+
+    func test_tree_inspector_should_validate_a_dependency_graph_with_resolvable_container_dependencies_as_uptree_parameters() {
+
+        let file = File(contents: """
+            final class Coordinator {
+                // weaver: value <= Int
+            }
+
+            final class AppDelegate {
+                // weaver: coordinator = Coordinator
+                // weaver: coordinator.scope = .transient
+
+                // weaver: viewController1 = ViewController1
+                // weaver: viewController1.scope = .transient
+            }
+
+            final class ViewController1: UIViewController {
+                // weaver: coordinator <= Coordinator
+
+                // weaver: viewController2 = ViewController2
+                // weaver: viewController2.scope = .transient
+            }
+
+            final class ViewController2: UIViewController {
+                // weaver: coordinator <- Coordinator
+            }
+            """)
+
+        do {
+            let lexer = Lexer(file, fileName: "test.swift")
+            let tokens = try lexer.tokenize()
+            let parser = Parser(tokens, fileName: "test.swift")
+            let syntaxTree = try parser.parse()
+            let linker = try Linker(syntaxTrees: [syntaxTree])
+            let inspector = Inspector(dependencyGraph: linker.dependencyGraph)
+            try inspector.validate()
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func test_tree_inspector_should_not_validate_a_dependency_graph_with_unresolvable_container_dependencies_as_uptree_parameters() {
+
+        let file = File(contents: """
+            final class Coordinator {
+                // weaver: value <= Int
+            }
+
+            final class AppDelegate {
+                // weaver: coordinator = Coordinator
+                // weaver: coordinator.scope = .transient
+
+                // weaver: viewController1 = ViewController1 <- UIViewController
+                // weaver: viewController1.scope = .transient
+
+                // weaver: viewController3 = ViewController3 <- UIViewController
+                // weaver: viewController3.scope = .transient
+            }
+
+            final class ViewController1: UIViewController {
+                // weaver: coordinator <= Coordinator
+
+                // weaver: viewController2 = ViewController2 <- UIViewController
+                // weaver: viewController2.scope = .transient
+            }
+
+            final class ViewController2: UIViewController {
+                // weaver: coordinator <- Coordinator
+            }
+
+            final class ViewController3: UIViewController {
+                // weaver: coordinator <- Coordinator
+            }
+        """)
+
+        do {
+            let lexer = Lexer(file, fileName: "test.swift")
+            let tokens = try lexer.tokenize()
+            let parser = Parser(tokens, fileName: "test.swift")
+            let syntaxTree = try parser.parse()
+            let linker = try Linker(syntaxTrees: [syntaxTree])
+            let inspector = Inspector(dependencyGraph: linker.dependencyGraph)
+            try inspector.validate()
+            XCTFail("Expected error.")
+        } catch let error as InspectorError {
+            print("error = \(error)")
+            XCTAssertEqual(error.description, """
+            test.swift:28: error: Invalid dependency: 'coordinator: Coordinator'. Dependency cannot be resolved.
+            test.swift:28: warning: Step 0: Tried to resolve dependency 'coordinator' in type 'ViewController3'.
+            test.swift:28: warning: Step 1: Tried to resolve dependency 'coordinator' in type 'AppDelegate'.
+            test.swift:28: error: Dependency 'coordinator' cannot declare parameters and be registered with a container scope. This must either have no parameters or itself be injected as a parameter to a parent depdenceny.
+            """)
+        } catch {
+            XCTFail("Unexpected error: \(error).")
+        }
+    }
+}


### PR DESCRIPTION
This will allow dependencies that have their own parameters to be injected as parameters and then referenced down the tree. If a dependency is used in multiple places, then every trace up the tree must meet the criteria of injection as a parameter or else a graph error will be thrown and Weaver will fail to resolve the graph.

By these new rules, scenario 1 will pass and scenario 2 will fail:

**Scenario 1**

```swift
--SomeManager-- 
  // weaver: value <= Value


--Controller1--
  // weaver: someManager <= SomeManager

  // weaver: controller2 = Controller2
  // weaver: controller2.scope = .transient


--Controller2--
  // weaver: someManager <- SomeManager


--AppDelegate--
  // weaver: someManager = SomeManager
  // weaver: someManager.scope = .transient

  // weaver: controller1 = Controller1
  // weaver: controller1.scope = transient


  func action() {
      let controller1 = dependencies.controller1(someManager: dependencies.someManager)
  } 
```


**Scenario 2**

```swift
--SomeManager-- 
  // weaver: value <= Value


--Controller1--
  // weaver: someManager <= SomeManager

  // weaver: controller2 = Controller2
  // weaver: controller2.scope = .transient


--Controller2--
  // weaver: someManager <- SomeManager


--AnotherController--
  // weaver: someManager <- SomeManager


--AppDelegate--
  // weaver: someManager = SomeManager
  // weaver: someManager.scope = .transient

  // weaver: controller1 = Controller1
  // weaver: controller1.scope = transient

  // weaver: anotherController = AnotherController
  // weaver: anotherController.scope = transient
```


In the second scenario, the tree would validate for:
 `AppDelegate -> Controller1 -> Controller2`

but would fail for:
`AppDelegate -> AnotherController`

as the dependency `someManager` in `AnotherController` would trace back up to the AppDelegate and not have a valid instance to reference.