### PR TITLE
Update DependencyContainer validation to include the entire runtime instantiation of the tree.

### DIFF
--- a/Sources/WeaverCodeGen/Linker.swift
+++ b/Sources/WeaverCodeGen/Linker.swift
@@ -26,9 +26,9 @@ final class DependencyContainer: Encodable, CustomDebugStringConvertible {
     fileprivate(set) var dependencyNamesByAbstractType = OrderedDictionary<AbstractType, Set<String>>()
     fileprivate(set) var dependencies = OrderedDictionary<String, Dependency>()
     
-    lazy var references = dependencies.orderedValues.filter { $0.kind == .reference }
-    lazy var registrations = dependencies.orderedValues.filter { $0.kind == .registration }
-    lazy var parameters = dependencies.orderedValues.filter { $0.kind == .parameter }
+    fileprivate(set) lazy var references = dependencies.orderedValues.filter { $0.kind == .reference }
+    fileprivate(set) lazy var registrations = dependencies.orderedValues.filter { $0.kind == .registration }
+    fileprivate(set) lazy var parameters = dependencies.orderedValues.filter { $0.kind == .parameter }
     
     /// Types from which this dependency container's associated type is being registered.
     fileprivate(set) var sources = Set<ConcreteType>()
@@ -48,7 +48,7 @@ final class DependencyContainer: Encodable, CustomDebugStringConvertible {
      
      Produces a dependency container with one embedding type: `Foo`.
     */
-    let embeddingTypes:  [ConcreteType]
+    let embeddingTypes: [ConcreteType]
     
     /// Location of the associated type declaration in the code.
     let fileLocation: FileLocation?
@@ -208,13 +208,13 @@ public final class DependencyGraph {
     fileprivate(set) var dependencyContainers = OrderedDictionary<ConcreteType, DependencyContainer>()
 
     /// All dependencies in order of appearance in the code.
-    lazy var dependencies = dependencyContainers.orderedValues.flatMap { $0.dependencies.orderedValues }
+    fileprivate(set) lazy var dependencies = dependencyContainers.orderedValues.flatMap { $0.dependencies.orderedValues }
 
     /// Count of types with annotations.
-    public lazy var injectableTypesCount = dependencyContainers.orderedValues.filter { $0.dependencies.isEmpty == false }.count
+    public fileprivate(set) lazy var injectableTypesCount = dependencyContainers.orderedValues.filter { $0.dependencies.isEmpty == false }.count
 
     /// Contains at least one annotation using a property wrapper.
-    lazy var hasPropertyWrapperAnnotations = dependencies.contains { $0.annotationStyle == .propertyWrapper }
+    fileprivate(set) lazy var hasPropertyWrapperAnnotations = dependencies.contains { $0.annotationStyle == .propertyWrapper }
 
     // MARK: - Cached data
     


### PR DESCRIPTION
This is a lighter weight implementation of the same feature.

This will allow dependencies that have their own parameters to be injected as parameters and then referenced down the tree. If a dependency is used in multiple places, then every trace up the tree must meet the criteria of injection as a parameter or else a graph error will be thrown and Weaver will fail to resolve the graph.

By these new rules, scenario 1 will pass and scenario 2 will fail:

**Scenario 1**

```swift
--SomeManager-- 
  // weaver: value <= Value


--Controller1--
  // weaver: someManager <= SomeManager

  // weaver: controller2 = Controller2
  // weaver: controller2.scope = .transient


--Controller2--
  // weaver: someManager <- SomeManager


--AppDelegate--
  // weaver: someManager = SomeManager
  // weaver: someManager.scope = .transient

  // weaver: controller1 = Controller1
  // weaver: controller1.scope = transient


  func action() {
      let controller1 = dependencies.controller1(someManager: dependencies.someManager)
  } 
```


**Scenario 2**

```swift
--SomeManager-- 
  // weaver: value <= Value


--Controller1--
  // weaver: someManager <= SomeManager

  // weaver: controller2 = Controller2
  // weaver: controller2.scope = .transient


--Controller2--
  // weaver: someManager <- SomeManager


--AnotherController--
  // weaver: someManager <- SomeManager


--AppDelegate--
  // weaver: someManager = SomeManager
  // weaver: someManager.scope = .transient

  // weaver: controller1 = Controller1
  // weaver: controller1.scope = transient

  // weaver: anotherController = AnotherController
  // weaver: anotherController.scope = transient
```


In the second scenario, the tree would validate for:
 `AppDelegate -> Controller1 -> Controller2`

but would fail for:
`AppDelegate -> AnotherController`

as the dependency `someManager` in `AnotherController` would trace back up to the AppDelegate and not have a valid instance to reference.