### PR TITLE
Update generated code so that transient builders always create a unique instance.

### DIFF
--- a/Sample/API/Generated/Weaver.swift
+++ b/Sample/API/Generated/Weaver.swift
@@ -15,125 +15,97 @@ final class MainDependencyContainer {
         onFatalError("Invalid memory graph. This is never suppose to happen. Please file a ticket at https://github.com/scribd/Weaver", file, line)
     }
 
-    private typealias ParametersCopier = (MainDependencyContainer) -> Void
-    private typealias Builder<T> = (ParametersCopier?) -> T
+    private lazy var provider = Provider(owner: self)
 
-    private func builder<T>(_ value: T) -> Builder<T> {
-        return { [weak self] copyParameters in
-            guard let self = self else {
-                MainDependencyContainer.fatalError()
-            }
-            copyParameters?(self)
-            return value
-        }
+    private var hostBuilder: Provider.Builder<Optional<String>> {
+        return provider.getBuilder("host", Optional<String>.self)
     }
 
-    private func weakOptionalBuilder<T>(_ value: Optional<T>) -> Builder<Optional<T>> where T: AnyObject {
-        return { [weak value] _ in value }
+    private var loggerBuilder: Provider.Builder<Logger> {
+        return provider.getBuilder("logger", Logger.self)
     }
 
-    private func weakBuilder<T>(_ value: T) -> Builder<T> where T: AnyObject {
-        return { [weak self, weak value] copyParameters in
-            guard let self = self, let value = value else {
-                MainDependencyContainer.fatalError()
-            }
-            copyParameters?(self)
-            return value
-        }
+    private var movieAPIBuilder: Provider.Builder<APIProtocol> {
+        return provider.getBuilder("movieAPI", APIProtocol.self)
     }
 
-    private func lazyBuilder<T>(_ builder: @escaping Builder<T>) -> Builder<T> {
-        var _value: T?
-        return { copyParameters in
-            if let value = _value {
-                return value
-            }
-            let value = builder(copyParameters)
-            _value = value
-            return value
-        }
-    }
-
-    private func weakLazyBuilder<T>(_ builder: @escaping Builder<T>) -> Builder<T> where T: AnyObject {
-        weak var _value: T?
-        return { copyParameters in
-            if let value = _value {
-                return value
-            }
-            let value = builder(copyParameters)
-            _value = value
-            return value
-        }
-    }
-
-    private static func fatalBuilder<T>() -> Builder<T> {
-        return { _ in
-            MainDependencyContainer.fatalError()
-        }
-    }
-
-    private var builders = Dictionary<String, Any>()
-    private func getBuilder<T>(for name: String, type _: T.Type) -> Builder<T> {
-        guard let builder = builders[name] as? Builder<T> else {
-            return MainDependencyContainer.fatalBuilder()
-        }
-        return builder
+    private var urlSessionBuilder: Provider.Builder<URLSession> {
+        return provider.getBuilder("urlSession", URLSession.self)
     }
 
     var host: Optional<String> {
-        return getBuilder(for: "host", type: Optional<String>.self)(nil)
+        return provider.build(hostBuilder, nil)
     }
 
     var logger: Logger {
-        return getBuilder(for: "logger", type: Logger.self)(nil)
+        return provider.build(loggerBuilder, nil)
     }
 
     var movieAPI: APIProtocol {
-        return getBuilder(for: "movieAPI", type: APIProtocol.self)(nil)
+        return provider.build(movieAPIBuilder, nil)
     }
 
     var urlSession: URLSession {
-        return getBuilder(for: "urlSession", type: URLSession.self)(nil)
+        return provider.build(urlSessionBuilder, nil)
     }
 
     fileprivate init() {
     }
 
+    private convenience init(provider: Provider) {
+        self.init()
+        self.provider = provider
+    }
+
     private func movieAPIDependencyResolver() -> MovieAPIDependencyResolver {
         let _self = MainDependencyContainer()
-        _self.builders["logger"] = lazyBuilder { (_: Optional<ParametersCopier>) -> Logger in return Logger() }
-        _self.builders["urlSession"] = _self.builder(urlSession)
-        _ = _self.getBuilder(for: "logger", type: Logger.self)(nil)
+        var _builders = Dictionary<String, Any>()
+        _builders["logger"] = Provider.lazyBuilder(
+             { (_: MainDependencyContainer, _: Optional<Provider.ParametersCopier>) -> Logger in return Logger() }
+        )
+        _builders["urlSession"] = urlSessionBuilder
+        _self.provider.addBuilders(_builders)
+        _ = _self.logger
         return _self
     }
 
     fileprivate func publicMovieAPIDependencyResolver(urlSession: URLSession) -> MovieAPIDependencyResolver {
         let _self = MainDependencyContainer()
-        _self.builders["logger"] = lazyBuilder { (_: Optional<ParametersCopier>) -> Logger in return Logger() }
-        _self.builders["urlSession"] = _self.builder(urlSession)
-        _ = _self.getBuilder(for: "logger", type: Logger.self)(nil)
+        var _builders = Dictionary<String, Any>()
+        _builders["logger"] = Provider.lazyBuilder(
+             { (_: MainDependencyContainer, _: Optional<Provider.ParametersCopier>) -> Logger in return Logger() }
+        )
+        _builders["urlSession"] = Provider.valueBuilder(urlSession)
+        _self.provider.addBuilders(_builders)
+        _ = _self.logger
         return _self
     }
 
     fileprivate func imageManagerDependencyResolver() -> ImageManagerDependencyResolver {
         let _self = MainDependencyContainer()
-        _self.builders["logger"] = lazyBuilder { (_: Optional<ParametersCopier>) -> Logger in return Logger() }
-        _self.builders["urlSession"] = lazyBuilder { [weak _self] (_: Optional<ParametersCopier>) -> URLSession in
-            guard let _self = _self else {
-                MainDependencyContainer.fatalError()
+        _self.provider = provider.transferred(to: _self)
+        var _builders = Dictionary<String, Any>()
+        let _inputProvider = _self.provider
+        _builders["logger"] = Provider.lazyBuilder(
+             { (_: MainDependencyContainer, _: Optional<Provider.ParametersCopier>) -> Logger in return Logger() }
+        )
+        _builders["urlSession"] = Provider.lazyBuilder(
+             { (owner: MainDependencyContainer, _: Optional<Provider.ParametersCopier>) -> URLSession in
+                let _inputContainer = MainDependencyContainer(provider: _inputProvider.transferred(to: owner))
+                return ImageManager.makeURLSession(_inputContainer as URLSessionInputDependencyResolver)
             }
-            return ImageManager.makeURLSession(_self as URLSessionInputDependencyResolver)
-        }
-        _self.builders["movieAPI"] = lazyBuilder { [weak _self] (_: Optional<ParametersCopier>) -> APIProtocol in
-            guard let _self = _self else {
-                MainDependencyContainer.fatalError()
+        )
+        _builders["movieAPI"] = Provider.lazyBuilder(
+             { (owner: MainDependencyContainer, _: Optional<Provider.ParametersCopier>) -> APIProtocol in
+                let _inputContainer = MainDependencyContainer(provider: _inputProvider.transferred(to: owner))
+                let __self = _inputContainer.movieAPIDependencyResolver()
+                return MovieAPI(injecting: __self)
             }
-            let __self = _self.movieAPIDependencyResolver()
-            return MovieAPI(injecting: __self)
-        }
-        _ = _self.getBuilder(for: "logger", type: Logger.self)(nil)
-        _ = _self.getBuilder(for: "urlSession", type: URLSession.self)(nil)
-        _ = _self.getBuilder(for: "movieAPI", type: APIProtocol.self)(nil)
+        )
+        _self.provider.addBuilders(_builders)
+        _ = _self.logger
+        _ = _self.urlSession
+        _ = _self.movieAPI
         return _self
     }
 
@@ -144,49 +116,56 @@ final class MainDependencyContainer {
 
     private func movieManagerDependencyResolver() -> MovieManagerDependencyResolver {
         let _self = MainDependencyContainer()
-        _self.builders["urlSession"] = lazyBuilder { [weak _self] (_: Optional<ParametersCopier>) -> URLSession in
-            guard let _self = _self else {
-                MainDependencyContainer.fatalError()
+        _self.provider = provider.transferred(to: _self)
+        var _builders = Dictionary<String, Any>()
+        let _inputProvider = _self.provider
+        _builders["urlSession"] = Provider.lazyBuilder(
+             { (owner: MainDependencyContainer, _: Optional<Provider.ParametersCopier>) -> URLSession in
+                let _inputContainer = MainDependencyContainer(provider: _inputProvider.transferred(to: owner))
+                return { _ in URLSession.shared }(_inputContainer as URLSessionInputDependencyResolver)
             }
-            return { _ in URLSession.shared }(_self as URLSessionInputDependencyResolver)
-        }
-        _self.builders["movieAPI"] = lazyBuilder { [weak _self] (_: Optional<ParametersCopier>) -> APIProtocol in
-            guard let _self = _self else {
-                MainDependencyContainer.fatalError()
+        )
+        _builders["movieAPI"] = Provider.lazyBuilder(
+             { (owner: MainDependencyContainer, _: Optional<Provider.ParametersCopier>) -> APIProtocol in
+                let _inputContainer = MainDependencyContainer(provider: _inputProvider.transferred(to: owner))
+                let __self = _inputContainer.movieAPIDependencyResolver()
+                return MovieAPI(injecting: __self)
             }
-            let __self = _self.movieAPIDependencyResolver()
-            return MovieAPI(injecting: __self)
-        }
-        _self.builders["logger"] = _self.builder(_self.logger)
-        _ = _self.getBuilder(for: "urlSession", type: URLSession.self)(nil)
-        _ = _self.getBuilder(for: "movieAPI", type: APIProtocol.self)(nil)
+        )
+        _builders["logger"] = _self.loggerBuilder
+        _self.provider.addBuilders(_builders)
+        _ = _self.urlSession
+        _ = _self.movieAPI
         return _self
     }
 
     fileprivate func publicMovieManagerDependencyResolver(host: Optional<String>,
                                                           logger: Logger) -> MovieManagerDependencyResolver {
         let _self = MainDependencyContainer()
-        _self.builders["urlSession"] = lazyBuilder { [weak _self] (_: Optional<ParametersCopier>) -> URLSession in
-            guard let _self = _self else {
-                MainDependencyContainer.fatalError()
+        _self.provider = provider.transferred(to: _self)
+        var _builders = Dictionary<String, Any>()
+        let _inputProvider = _self.provider
+        _builders["urlSession"] = Provider.lazyBuilder(
+             { (owner: MainDependencyContainer, _: Optional<Provider.ParametersCopier>) -> URLSession in
+                let _inputContainer = MainDependencyContainer(provider: _inputProvider.transferred(to: owner))
+                return { _ in URLSession.shared }(_inputContainer as URLSessionInputDependencyResolver)
             }
-            return { _ in URLSession.shared }(_self as URLSessionInputDependencyResolver)
-        }
-        _self.builders["movieAPI"] = lazyBuilder { [weak _self] (_: Optional<ParametersCopier>) -> APIProtocol in
-            guard let _self = _self else {
-                MainDependencyContainer.fatalError()
+        )
+        _builders["movieAPI"] = Provider.lazyBuilder(
+             { (owner: MainDependencyContainer, _: Optional<Provider.ParametersCopier>) -> APIProtocol in
+                let _inputContainer = MainDependencyContainer(provider: _inputProvider.transferred(to: owner))
+                let __self = _inputContainer.movieAPIDependencyResolver()
+                return MovieAPI(injecting: __self)
             }
-            let __self = _self.movieAPIDependencyResolver()
-            return MovieAPI(injecting: __self)
-        }
-        _self.builders["host"] = _self.builder(host)
-        _self.builders["logger"] = _self.builder(logger)
-        _ = _self.getBuilder(for: "urlSession", type: URLSession.self)(nil)
-        _ = _self.getBuilder(for: "movieAPI", type: APIProtocol.self)(nil)
+        )
+        _builders["host"] = Provider.valueBuilder(host)
+        _builders["logger"] = Provider.valueBuilder(logger)
+        _self.provider.addBuilders(_builders)
+        _ = _self.urlSession
+        _ = _self.movieAPI
         return _self
     }
 }
-
 
 protocol HostResolver: AnyObject {
     var host: Optional<String> { get }
@@ -240,5 +219,100 @@ extension MovieManager {
         let _self = MainDependencyContainer()
         let __self = _self.publicMovieManagerDependencyResolver(host: host, logger: logger)
         self.init(injecting: __self)
+    }
+}
+
+// MARK: - Provider
+
+private final class Provider {
+
+    typealias ParametersCopier = (MainDependencyContainer) -> Void
+    typealias Builder<T> = (MainDependencyContainer, ParametersCopier?) -> T
+
+    private(set) weak var owner: MainDependencyContainer?
+    private(set) var builders: Dictionary<String, Any>
+
+    init(owner: MainDependencyContainer?,
+         builders: Dictionary<String, Any> = [:]) {
+        self.owner = owner
+        self.builders = builders
+    }
+}
+
+private extension Provider {
+
+    func addBuilders(_ builders: Dictionary<String, Any>) {
+        builders.forEach { key, value in
+            self.builders[key] = value
+        }
+    }
+
+    func setBuilder<T>(_ name: String, _ builder: @escaping Builder<T>) {
+        builders[name] = builder
+    }
+
+    func getBuilder<T>(_ name: String, _ type: T.Type) -> Builder<T> {
+        guard let builder = builders[name] as? Builder<T> else {
+            return Provider.fatalBuilder()
+        }
+        return builder
+    }
+
+    func build<T>(_ builder: Builder<T>, _ copier: ParametersCopier?) -> T {
+        guard let owner = owner else {
+            MainDependencyContainer.fatalError()
+        }
+        return builder(owner, copier)
+    }
+
+    func transferred(to newOwner: MainDependencyContainer) -> Provider {
+        return Provider(owner: newOwner, builders: builders)
+    }
+}
+
+private extension Provider {
+
+    static func valueBuilder<T>(_ value: T) -> Builder<T> {
+        return { owner, copyParameters in
+            copyParameters?(owner)
+            return value
+        }
+    }
+
+    static func weakOptionalValueBuilder<T>(_ value: Optional<T>) -> Builder<Optional<T>> where T: AnyObject {
+        return { [weak value] owner, copyParameters in
+            copyParameters?(owner)
+            return value
+        }
+    }
+
+    static func lazyBuilder<T>(_ builder: @escaping Builder<T>) -> Builder<T> {
+        var _value: T?
+        return { owner, copyParameters in
+            if let value = _value {
+                return value
+            }
+            let value = builder(owner, copyParameters)
+            _value = value
+            return value
+        }
+    }
+
+    static func weakLazyBuilder<T>(_ builder: @escaping Builder<T>) -> Builder<T> where T: AnyObject {
+        weak var _value: T?
+        return { owner, copyParameters in
+            if let value = _value {
+                return value
+            }
+            let value = builder(owner, copyParameters)
+            _value = value
+            return value
+        }
+    }
+
+    static func fatalBuilder<T>() -> Builder<T> {
+        return { _, _ in
+            MainDependencyContainer.fatalError()
+        }
     }
 }

--- a/Sources/WeaverCodeGen/MetaUtils.swift
+++ b/Sources/WeaverCodeGen/MetaUtils.swift
@@ -8,6 +8,10 @@
 import Foundation
 import Meta
 
+extension Reference {
+    static let provider = Reference.named("provider")
+}
+
 extension TypeIdentifier {
     
     static let mainDependencyContainer = TypeIdentifier(name: "MainDependencyContainer")
@@ -17,17 +21,19 @@ extension TypeIdentifier {
     static let abstractType = TypeIdentifier(name: "AbstractType")
     static let concreteType = TypeIdentifier(name: "ConcreteType")
     static let resolver = TypeIdentifier(name: "Resolver")
+    static let provider = TypeIdentifier(name: "Provider")
 
     static func builder(of typeID: TypeIdentifier) -> TypeIdentifier {
-        return TypeIdentifier(name: "Builder").adding(genericParameter: typeID)
+        return TypeIdentifier(name: "Provider.Builder").adding(genericParameter: typeID)
     }
 }
 
 extension Variable {
     
+    static let owner = Variable(name: "owner")
+    static let `self` = Variable(name: "self")
     static let _self = Variable(name: "_self")
     static let __self = Variable(name: "__self")
-    static let __mainSelf = Variable(name: "__mainSelf")
     static let source = Variable(name: "source")
     static let value = Variable(name: "_value")
     static let proxySelf = Variable(name: "value")
@@ -205,5 +211,32 @@ extension String {
         guard let firstChar = _self.first else { return String() }
         _self.removeFirst()
         return prefix + firstChar.uppercased() + _self
+    }
+}
+
+// MARK: - Provider
+
+extension Reference {
+
+    static func providerFunction(name: String, reference: Reference) -> Reference {
+        return TypeIdentifier.provider.reference + .named(name) | .call(Tuple()
+            .adding(parameter: TupleParameter(value: reference))
+        )
+    }
+
+    static func valueBuilder(value: Reference) -> Reference {
+        return providerFunction(name: "valueBuilder", reference: value)
+    }
+
+    static func weakOptionalValueBuilder(value: Reference) -> Reference {
+        return providerFunction(name: "weakOptionalValueBuilder", reference: value)
+    }
+
+    static func lazyBuilder(body: FunctionBody) -> Reference {
+        return providerFunction(name: "lazyBuilder", reference: .block(body))
+    }
+
+    static func weakLazyBuilder(body: FunctionBody) -> Reference {
+        return providerFunction(name: "weakLazyBuilder", reference: .block(body))
     }
 }

--- a/Sources/WeaverCodeGen/SwiftGenerator.swift
+++ b/Sources/WeaverCodeGen/SwiftGenerator.swift
@@ -79,8 +79,10 @@ private final class MetaDependencyDeclaration: Hashable {
     
     let type: Dependency.`Type`
     
+    let scope: Scope
+
     let parameters: [Dependency]
-    
+
     private let includeTypeInName: Bool
     
     private let includeParametersInName: Bool
@@ -92,6 +94,7 @@ private final class MetaDependencyDeclaration: Hashable {
         
         name = dependency.dependencyName
         type = dependency.type
+        scope = dependency.configuration.scope
         self.includeTypeInName = includeTypeInName
         self.includeParametersInName = includeParametersInName
         
@@ -122,7 +125,8 @@ private final class MetaDependencyDeclaration: Hashable {
     }()
     
     lazy var declarationName = "\(name)\(desambiguationHash.flatMap { "_\($0)" } ?? String())"
-    lazy var buildersSubcriptGet = "builders[\"\(declarationName)\"]"
+    lazy var builderName = "\(declarationName)Builder"
+    lazy var buildersSubcript = "_builders[\"\(declarationName)\"]"
     lazy var resolverTypeName = "\(name.typeCase)\(desambiguationHash.flatMap { "_\($0)_" } ?? String())Resolver"
     lazy var setterName = "set\(name.typeCase)\(desambiguationHash.flatMap { "_\($0)" } ?? String())"
     lazy var setterTypeName = "\(name.typeCase)\(desambiguationHash.flatMap { "_\($0)_" } ?? String())Setter"
@@ -264,8 +268,7 @@ private final class MetaWeaverFile {
         return try [
             [
                 EmptyLine(),
-                mainDependencyContainer(),
-                EmptyLine()
+                mainDependencyContainer()
             ],
             resolvers(),
             [
@@ -281,7 +284,8 @@ private final class MetaWeaverFile {
             inputDependencyResolvers(),
             dependencyResolverProxies(),
             publicDependencyInitExtensions(),
-            propertyWrappers()
+            propertyWrappers(),
+            providerClassAndFunctions()
         ].flatMap { $0 }
     }
     
@@ -318,7 +322,7 @@ private extension MetaWeaverFile {
             .with(objc: doesSupportObjc)
             .adding(inheritedType: doesSupportObjc ? .nsObject : nil)
             .adding(member: PlainCode(code: """
-            
+
 static var onFatalError: (String, StaticString, UInt) -> Never = { message, file, line in
     Swift.fatalError(message, file: file, line: line)
 }
@@ -327,70 +331,7 @@ fileprivate static func fatalError(file: StaticString = #file, line: UInt = #lin
     onFatalError("Invalid memory graph. This is never suppose to happen. Please file a ticket at https://github.com/scribd/Weaver", file, line)
 }
 
-private typealias ParametersCopier = (\(TypeIdentifier.mainDependencyContainer.swiftString)) -> Void
-private typealias Builder<T> = (ParametersCopier?) -> T
-
-private func builder<T>(_ value: T) -> Builder<T> {
-    return { [weak self] copyParameters in
-        guard let self = self else {
-            \(TypeIdentifier.mainDependencyContainer.swiftString).fatalError()
-        }
-        copyParameters?(self)
-        return value
-    }
-}
-
-private func weakOptionalBuilder<T>(_ value: Optional<T>) -> Builder<Optional<T>> where T: AnyObject {
-    return { [weak value] _ in value }
-}
-
-private func weakBuilder<T>(_ value: T) -> Builder<T> where T: AnyObject {
-    return { [weak self, weak value] copyParameters in
-        guard let self = self, let value = value else {
-            \(TypeIdentifier.mainDependencyContainer.swiftString).fatalError()
-        }
-        copyParameters?(self)
-        return value
-    }
-}
-
-private func lazyBuilder<T>(_ builder: @escaping Builder<T>) -> Builder<T> {
-    var _value: T?
-    return { copyParameters in
-        if let value = _value {
-            return value
-        }
-        let value = builder(copyParameters)
-        _value = value
-        return value
-    }
-}
-
-private func weakLazyBuilder<T>(_ builder: @escaping Builder<T>) -> Builder<T> where T: AnyObject {
-    weak var _value: T?
-    return { copyParameters in
-        if let value = _value {
-            return value
-        }
-        let value = builder(copyParameters)
-        _value = value
-        return value
-    }
-}
-
-private static func fatalBuilder<T>() -> Builder<T> {
-    return { _ in
-        \(TypeIdentifier.mainDependencyContainer.swiftString).fatalError()
-    }
-}
-
-private var builders = Dictionary<String, Any>()
-private func getBuilder<T>(for name: String, type _: T.Type) -> Builder<T> {
-    guard let builder = builders[name] as? Builder<T> else {
-        return \(TypeIdentifier.mainDependencyContainer.swiftString).fatalBuilder()
-    }
-    return builder
-}
+private lazy var provider = Provider(owner: self)
 """))
             .adding(member: dependencyGraph.hasPropertyWrapperAnnotations ? PlainCode(code: """
 
@@ -428,6 +369,15 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
             .adding(member: Function(kind: .`init`(convenience: false, optional: false))
                 .with(override: doesSupportObjc)
                 .with(accessLevel: .fileprivate)
+            )
+            .adding(member: EmptyLine())
+            .adding(member: Function(kind: .`init`(convenience: true, optional: false))
+                .with(accessLevel: .private)
+                .adding(parameter: FunctionParameter(name: "provider", type: .provider))
+                .adding(members: [
+                    Reference.named(.`self`) + .named("init") | .call(),
+                    Assignment(variable: Reference.named(.`self`) + .named("provider"), value: Reference.named("provider"))
+                ])
             )
             .adding(members: try dependencyResolverCopyMethods())
     }
@@ -520,17 +470,32 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
     }
     
     func resolversImplementation() throws -> [TypeBodyMember] {
-        return try orderedDeclarations.flatMap { declaration -> [TypeBodyMember] in
+
+        let builderGetters = orderedDeclarations.flatMap { declaration -> [TypeBodyMember] in
+            var members: [TypeBodyMember] = [EmptyLine()]
+
+            members += [
+                ComputedProperty(variable: Variable(name: declaration.builderName)
+                    .with(type: .builder(of: declaration.type.typeID)))
+                    .with(accessLevel: .private)
+                    .adding(member: Return(value: .provider + .named("getBuilder") | .call(Tuple()
+                        .adding(parameter: TupleParameter(value: Value.string(declaration.declarationName)))
+                        .adding(parameter: TupleParameter(value: declaration.type.typeID.reference + .named(.`self`)))
+                    )))
+            ]
+
+            return members
+        }
+
+        let getters = try orderedDeclarations.flatMap { declaration -> [TypeBodyMember] in
             var members: [TypeBodyMember] = [EmptyLine()]
             
             if declaration.parameters.isEmpty {
                 members += [
                     ComputedProperty(variable: Variable(name: declaration.declarationName)
                         .with(type: declaration.type.typeID))
-                        .adding(member: Return(value: .named("getBuilder") | .call(Tuple()
-                            .adding(parameter: TupleParameter(name: "for", value: Value.string(declaration.declarationName)))
-                            .adding(parameter: TupleParameter(name: "type", value: declaration.type.typeID.reference + .named(.`self`)))
-                        ) | .call(Tuple()
+                        .adding(member: Return(value: .provider + .named("build") | .call(Tuple()
+                            .adding(parameter: TupleParameter(value: Value.reference(.named(declaration.builderName))))
                             .adding(parameter: TupleParameter(value: Value.nil))
                         )))
                 ]
@@ -543,32 +508,27 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
                             return FunctionParameter(name: parameter.dependencyName, type: parameter.type.typeID)
                                 .with(escaping: isEscapingByDeclaration[declaration] ?? false)
                         })
-                        .adding(member: Assignment(
-                            variable: Variable(name: "builder").with(type: TypeIdentifier.builder(of: declaration.type.typeID)),
-                            value: .named("getBuilder") | .call(Tuple()
-                                .adding(parameter: TupleParameter(name: "for", value: Value.string(declaration.declarationName)))
-                                .adding(parameter: TupleParameter(name: "type", value: declaration.type.typeID.reference + .named(.`self`)))
-                            )
-                        ))
-                        .adding(member: Return(value: .named("builder") | .block(FunctionBody()
+                        .adding(member: Return(value: .provider + .named("build") | .call(Tuple()
+                                .adding(parameter: TupleParameter(value: Value.reference(.named(declaration.builderName))))
+                            ) | .block(FunctionBody()
                             .adding(context: declaration.parameters.compactMap { parameter in
                                 guard parameter.configuration.scope == .weak else { return nil }
                                 return FunctionBodyContext(name: parameter.dependencyName, kind: .weak)
                             })
-                            .adding(parameter: FunctionBodyParameter(name: Variable._self.name))
+                            .adding(parameter: FunctionBodyParameter(name: Variable.owner.name))
                             .adding(members: try declaration.parameters.map { parameter in
                                 let declaration = try self.declaration(for: parameter)
-                                let builderReference: Reference
+
+                                let parameterProviderReference: Reference
                                 if parameter.configuration.scope == .weak {
-                                    builderReference = .named("weakOptionalBuilder")
+                                    parameterProviderReference = .weakOptionalValueBuilder(value: .named(parameter.dependencyName))
                                 } else {
-                                    builderReference = .named("builder")
+                                    parameterProviderReference = .valueBuilder(value: .named(parameter.dependencyName))
                                 }
-                                return Assignment(
-                                    variable: Variable._self.reference + .named(declaration.buildersSubcriptGet),
-                                    value: Variable._self.reference + builderReference | .call(Tuple()
-                                        .adding(parameter: TupleParameter(value: Reference.named(parameter.dependencyName)))
-                                    )
+
+                                return Variable.owner.reference + .provider + .named("setBuilder") | .call(Tuple()
+                                    .adding(parameter: TupleParameter(value: Value.string(declaration.declarationName)))
+                                    .adding(parameter: TupleParameter(value: Value.reference(parameterProviderReference)))
                                 )
                             })
                         )))
@@ -577,6 +537,8 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
             
             return members
         }
+
+        return builderGetters + getters
     }
 
     func resolvers() throws -> [FileBodyMember] {
@@ -610,15 +572,19 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
     
     func settersImplementation() -> [TypeBodyMember] {
         return setterDeclarations.flatMap { declaration -> [TypeBodyMember] in
-            [
+            let parameterProviderReference: Reference
+            if declaration.scope == .weak {
+                parameterProviderReference = .weakOptionalValueBuilder(value: .named(declaration.name))
+            } else {
+                parameterProviderReference = .valueBuilder(value: .named("value"))
+            }
+            return [
                 EmptyLine(),
                 Function(kind: .named(declaration.setterName))
                     .adding(parameter: FunctionParameter(alias: "_", name: "value", type: declaration.type.typeID))
-                    .adding(member: Assignment(
-                        variable: Reference.named(declaration.buildersSubcriptGet),
-                        value: Reference.named("builder") | .call(Tuple()
-                            .adding(parameter: TupleParameter(value: Reference.named("value")))
-                        )
+                    .adding(member: Reference.provider + .named("setBuilder") | .call(Tuple()
+                        .adding(parameter: TupleParameter(value: Value.string(declaration.declarationName)))
+                        .adding(parameter: TupleParameter(value: Value.reference(parameterProviderReference)))
                     ))
             ]
         }
@@ -738,7 +704,22 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
         
         let accessLevel: Meta.AccessLevel =
             (inputReferences.isEmpty && dependencyContainer.parameters.isEmpty) || publicInterface ? .fileprivate : .private
-        
+
+        let functionParameterValues: [MetaDependencyDeclaration] = publicInterface ? try inputReferences.compactMap { reference in
+            let declaration = try self.declaration(for: reference)
+            guard selfReferenceDeclarations.contains(declaration) == false else { return nil }
+            return declaration
+        } : []
+
+        let hasInputDependencies: Bool = dependencyContainer.registrations.reduce(false) { boolResult, registration in
+            if boolResult { return true }
+            guard let declaration = try? self.declaration(for: registration) else { return false }
+            guard let target = try? dependencyGraph.dependencyContainer(for: registration) else { return false }
+            return target.dependencies.isEmpty == false ||
+                registration.configuration.customBuilder != nil ||
+                declaration.parameters.isEmpty == false
+        }
+
         var members: [TypeBodyMember] = [
             EmptyLine(),
             Function(kind: .named(publicInterface ?
@@ -750,12 +731,15 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
                 .adding(parameter: containsDeclarationBasedOnSource && publicInterface == false ?
                     FunctionParameter(alias: "_", name: Variable.source.name, type: .string) : nil
                 )
-                .adding(parameters: publicInterface ? try inputReferences.compactMap { reference in
-                    let declaration = try self.declaration(for: reference)
-                    guard selfReferenceDeclarations.contains(declaration) == false else { return nil }
+                .adding(parameters: functionParameterValues.map { declaration in
                     return FunctionParameter(name: declaration.declarationName, type: declaration.type.typeID)
-                } : [])
+                })
                 .adding(member: Assignment(variable: Variable._self, value: TypeIdentifier.mainDependencyContainer.reference | .call()))
+                .adding(member: hasInputDependencies ? Assignment(variable: Variable._self.reference + .provider, value: Reference.provider + .named("transferred") | .call(Tuple()
+                    .adding(parameter: TupleParameter(name: "to", value: Variable._self.reference))
+                )) : nil)
+                .adding(member: Assignment(variable: Variable(name: "_builders").with(immutable: false), value: Reference.named("Dictionary<String, Any>") | .call()))
+                .adding(member: hasInputDependencies ? Assignment(variable: Variable(name: "_inputProvider"), value: Variable._self.reference + .provider) : nil)
                 .adding(members: try dependencyContainer.registrations.compactMap { registration in
                     try copyAssignment(for: registration, from: dependencyContainer)
                 })
@@ -765,22 +749,32 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
                     guard selfReferenceDeclarations.contains(declaration) == false else { return [] }
 
                     let assignments: (MetaDependencyDeclaration) -> [Assignment] = { resolvedDeclaration in
+                        let inputNames = functionParameterValues.map { $0.name }
+
                         let isRootDependencyContainer = dependencyContainer.sources.isEmpty && publicInterface == false
-                        let builderValue = Variable._self.reference + .named("builder") | .call(Tuple()
-                            .adding(parameter: TupleParameter(value:
-                                (isRootDependencyContainer ? Variable._self.reference + .none : .none) | .named(resolvedDeclaration.declarationName)
-                            ))
-                        )
+                        let isParameter = inputNames.contains(resolvedDeclaration.name)
+                        let shouldHoldSelfReference = isRootDependencyContainer || isParameter
+
+                        let providerValue: Reference
+                        if inputNames.contains(resolvedDeclaration.name) {
+                            if resolvedDeclaration.scope == .weak {
+                                providerValue = .weakOptionalValueBuilder(value: .named(resolvedDeclaration.name))
+                            } else {
+                                providerValue = .valueBuilder(value: .named(resolvedDeclaration.name))
+                            }
+                        } else {
+                            providerValue = (shouldHoldSelfReference ? Variable._self.reference + .none : .none) | .named(resolvedDeclaration.builderName)
+                        }
 
                         var assignments = [Assignment(
-                            variable: Variable._self.reference + .named(declaration.buildersSubcriptGet),
-                            value: builderValue
+                            variable: Reference.named(declaration.buildersSubcript),
+                            value: providerValue
                         )]
 
                         if resolvedDeclaration.declarationName != declaration.declarationName {
                             assignments += [Assignment(
-                                variable: Variable._self.reference + .named(resolvedDeclaration.buildersSubcriptGet),
-                                value: builderValue
+                                variable: Reference.named(resolvedDeclaration.buildersSubcript),
+                                value: providerValue
                             )]
                         }
 
@@ -809,6 +803,9 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
                         }
                     }
                 })
+                .adding(member: Variable._self.reference + .provider + .named("addBuilders") | .call(Tuple()
+                    .adding(parameter: TupleParameter(value: Reference.named("_builders")))
+                ))
                 .adding(members: try dependencyContainer.registrations.compactMap { registration in
                     guard registration.configuration.setter == false else { return nil }
                     switch registration.configuration.scope {
@@ -816,12 +813,7 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
                         let declaration = try self.declaration(for: registration)
                         return Assignment(
                             variable: Reference.named("_"),
-                            value: Variable._self.reference + .named("getBuilder") | .call(Tuple()
-                                .adding(parameter: TupleParameter(name: "for", value: Value.string(declaration.declarationName)))
-                                .adding(parameter: TupleParameter(name: "type", value: declaration.type.typeID.reference + .named(.`self`)))
-                            ) | .call(Tuple()
-                                .adding(parameter: TupleParameter(value: Value.nil))
-                            )
+                            value: Variable._self.reference + .named(declaration.name)
                         )
                     case .lazy,
                          .weak,
@@ -879,9 +871,6 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
         let target = try dependencyGraph.dependencyContainer(for: registration)
         let targetContainsDeclarationBasedOnSource = try containsDeclarationBasedOnSource(in: target)
         let targetContainsAmbiguousDeclarations = try containsAmbiguousDeclarations(in: target)
-        let targetSelfReferences = try target.references.filter { reference in
-            try dependencyGraph.isSelfReference(reference)
-        }
         let targetHasPropertyWrapperAnnotations = target.dependencies.orderedValues.contains {
             $0.annotationStyle == .propertyWrapper
         }
@@ -895,33 +884,38 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
         let containsAmbiguousDeclarations = try self.containsAmbiguousDeclarations(in: dependencyContainer)
 
         let resolverReference: Reference?
-        let shouldUnwrapResolverReference: Bool
         var builderReference: Reference
+
+        let shouldUnwrapResolverReference: Bool
+        let isTypecastingAsResolver: Bool
+
         if let customBuilder = registration.configuration.customBuilder {
             switch target.declarationSource {
             case .type:
-                resolverReference = hasInputDependencies ? Variable._self.reference + concreteType.dependencyResolverVariable.reference | .call(Tuple()
+                resolverReference = hasInputDependencies ? Reference.named("_inputContainer") + concreteType.dependencyResolverVariable.reference | .call(Tuple()
                     .adding(parameter: targetContainsDeclarationBasedOnSource ? TupleParameter(value: Value.string(dependencyContainer.type.description)) : nil)
                 ) : nil
                 builderReference = .named(customBuilder) | .call(Tuple()
                     .adding(parameter: hasInputDependencies ? TupleParameter(value: Variable.__self.reference) : nil)
                 )
                 shouldUnwrapResolverReference = false
+                isTypecastingAsResolver = false
             case .reference,
                  .registration:
                 resolverReference = containsAmbiguousDeclarations ? dependencyContainer.type.dependencyResolverProxyTypeID.reference | .call(Tuple()
-                    .adding(parameter: TupleParameter(value: Variable._self.reference))
+                    .adding(parameter: TupleParameter(value: Reference.named("_inputContainer")))
                 ) : nil
                 builderReference = .named(customBuilder) | .call(Tuple()
                     .adding(parameter: TupleParameter(value:
-                        (containsAmbiguousDeclarations ? Variable.__self.reference + Variable.proxySelf.reference : Variable._self.reference) |
+                        (containsAmbiguousDeclarations ? Variable.__self.reference + Variable.proxySelf.reference : Reference.named("_inputContainer")) |
                         .as | target.type.inputDependencyResolverTypeID.reference
                     ))
                 )
                 shouldUnwrapResolverReference = containsAmbiguousDeclarations
+                isTypecastingAsResolver = true
             }
         } else {
-            resolverReference = hasInputDependencies ? Variable._self.reference + concreteType.dependencyResolverVariable.reference | .call(Tuple()
+            resolverReference = hasInputDependencies ? Reference.named("_inputContainer") + concreteType.dependencyResolverVariable.reference | .call(Tuple()
                 .adding(parameter: targetContainsDeclarationBasedOnSource ? TupleParameter(value: Value.string(dependencyContainer.type.description)) : nil)
             ) : nil
             builderReference = concreteType.typeID.reference | .call(Tuple()
@@ -931,74 +925,60 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
                 ) : nil)
             )
             shouldUnwrapResolverReference = targetContainsAmbiguousDeclarations
+            isTypecastingAsResolver = false
         }
-        
-        let builderFunction: Reference
-        switch registration.configuration.scope {
-        case .container,
-             .lazy:
-            builderFunction = .named("lazyBuilder")
-        case .weak:
-            builderFunction = .named("weakLazyBuilder")
-        case .transient:
-            builderFunction = .none
-        }
-        
-        builderReference = builderFunction | .block(FunctionBody()
+
+        let hasResolverReference = resolverReference != nil
+        let requiresOwner = hasResolverReference || isTypecastingAsResolver
+
+        let functionBody = FunctionBody()
+            .adding(parameter: FunctionBodyParameter(
+                name: requiresOwner ? "owner" : nil,
+                type: .mainDependencyContainer
+            ))
             .adding(parameter: FunctionBodyParameter(
                 name: hasParameters ? "copyParameters" : nil,
-                type: .optional(wrapped: TypeIdentifier(name: "ParametersCopier"))
+                type: .optional(wrapped: TypeIdentifier(name: "Provider.ParametersCopier"))
             ))
             .with(resultType: declaration.type.typeID)
-            .adding(context: hasInputDependencies ? FunctionBodyContext(name: Variable._self.name, kind: .weak) : nil)
             .adding(member: targetHasPropertyWrapperAnnotations ? PlainCode(code: """
             defer { MainDependencyContainer._dynamicResolversLock.unlock() }
             MainDependencyContainer._dynamicResolversLock.lock()
             """) : nil)
-            .adding(member: hasInputDependencies ?
-                Guard(assignment: Assignment(variable: Variable._self, value: Variable._self.reference))
-                    .adding(member: TypeIdentifier.mainDependencyContainer.reference + .named("fatalError") | .call()) : nil)
+            .adding(member: requiresOwner ?
+                Assignment(variable: Variable(name: "_inputContainer"), value: TypeIdentifier.mainDependencyContainer.reference | .call(Tuple()
+                    .adding(parameter: TupleParameter(name: "provider", value: Reference.named("_inputProvider") + .named("transferred") | .call(Tuple()
+                        .adding(parameter: TupleParameter(name: "to", value: Variable.owner.reference))
+                    )))
+                ))
+            : nil)
             .adding(member: resolverReference.flatMap {
                 Assignment(variable: Variable.__self, value: $0)
             })
             .adding(member: hasParameters ? .named("copyParameters") | .unwrap | .call(Tuple()
                 .adding(parameter: TupleParameter(
-                    value: (resolverReference != nil ? Variable.__self : Variable._self).reference |
+                    value: (hasResolverReference ? Variable.__self : Variable.owner).reference |
                         (shouldUnwrapResolverReference ? +Variable.proxySelf.reference : .none) |
                         .named(" as! ") |
                         TypeIdentifier.mainDependencyContainer.reference
                 ))
             ) : nil)
-            .adding(members: targetSelfReferences.isEmpty == false ? try [
-                Assignment(
-                    variable: Variable.__mainSelf,
-                    value: (resolverReference != nil ? Variable.__self : Variable._self).reference |
-                        (shouldUnwrapResolverReference ? +Variable.proxySelf.reference : .none) |
-                        .named(" as! ") |
-                        TypeIdentifier.mainDependencyContainer.reference
-                ),
-                Assignment(
-                    variable: Variable.value,
-                    value: builderReference
-                )
-            ] + targetSelfReferences.map { selfReference in
-                let declaration = try self.declaration(for: selfReference)
-                return Assignment(
-                    variable: Variable.__mainSelf.reference + .named(declaration.buildersSubcriptGet),
-                    value: Variable.__mainSelf.reference + .named("weakBuilder") | .call(Tuple()
-                        .adding(parameter: TupleParameter(value: Variable.value.reference))
-                    )
-                )
-            } + [
-                Return(value: Variable.value.reference)
-            ] : [
-                Return(value: builderReference)
-            ])
-        )
-        
+            .adding(member: Return(value: builderReference))
+
+        let builderFunction: Reference
+        switch registration.configuration.scope {
+        case .container,
+             .lazy:
+            builderFunction = .lazyBuilder(body: functionBody)
+        case .weak:
+            builderFunction = .weakLazyBuilder(body: functionBody)
+        case .transient:
+            builderFunction = .block(functionBody)
+        }
+
         return Assignment(
-            variable: Variable._self.reference + .named(declaration.buildersSubcriptGet),
-            value: builderReference
+            variable: Reference.named(declaration.buildersSubcript),
+            value: builderFunction
         )
     }
     
@@ -1224,6 +1204,108 @@ private extension MetaWeaverFile {
                     )))
             ]
         }
+    }
+
+    func providerClassAndFunctions() throws -> [FileBodyMember] {
+        return [
+            EmptyLine(),
+            PlainCode(code: """
+            // MARK: - Provider
+
+            private final class Provider {
+
+                typealias ParametersCopier = (MainDependencyContainer) -> Void
+                typealias Builder<T> = (MainDependencyContainer, ParametersCopier?) -> T
+
+                private(set) weak var owner: MainDependencyContainer?
+                private(set) var builders: Dictionary<String, Any>
+
+                init(owner: MainDependencyContainer?,
+                     builders: Dictionary<String, Any> = [:]) {
+                    self.owner = owner
+                    self.builders = builders
+                }
+            }
+
+            private extension Provider {
+
+                func addBuilders(_ builders: Dictionary<String, Any>) {
+                    builders.forEach { key, value in
+                        self.builders[key] = value
+                    }
+                }
+
+                func setBuilder<T>(_ name: String, _ builder: @escaping Builder<T>) {
+                    builders[name] = builder
+                }
+
+                func getBuilder<T>(_ name: String, _ type: T.Type) -> Builder<T> {
+                    guard let builder = builders[name] as? Builder<T> else {
+                        return Provider.fatalBuilder()
+                    }
+                    return builder
+                }
+
+                func build<T>(_ builder: Builder<T>, _ copier: ParametersCopier?) -> T {
+                    guard let owner = owner else {
+                        MainDependencyContainer.fatalError()
+                    }
+                    return builder(owner, copier)
+                }
+
+                func transferred(to newOwner: MainDependencyContainer) -> Provider {
+                    return Provider(owner: newOwner, builders: builders)
+                }
+            }
+
+            private extension Provider {
+
+                static func valueBuilder<T>(_ value: T) -> Builder<T> {
+                    return { owner, copyParameters in
+                        copyParameters?(owner)
+                        return value
+                    }
+                }
+
+                static func weakOptionalValueBuilder<T>(_ value: Optional<T>) -> Builder<Optional<T>> where T: AnyObject {
+                    return { [weak value] owner, copyParameters in
+                        copyParameters?(owner)
+                        return value
+                    }
+                }
+
+                static func lazyBuilder<T>(_ builder: @escaping Builder<T>) -> Builder<T> {
+                    var _value: T?
+                    return { owner, copyParameters in
+                        if let value = _value {
+                            return value
+                        }
+                        let value = builder(owner, copyParameters)
+                        _value = value
+                        return value
+                    }
+                }
+
+                static func weakLazyBuilder<T>(_ builder: @escaping Builder<T>) -> Builder<T> where T: AnyObject {
+                    weak var _value: T?
+                    return { owner, copyParameters in
+                        if let value = _value {
+                            return value
+                        }
+                        let value = builder(owner, copyParameters)
+                        _value = value
+                        return value
+                    }
+                }
+
+                static func fatalBuilder<T>() -> Builder<T> {
+                    return { _, _ in
+                        MainDependencyContainer.fatalError()
+                    }
+                }
+            }
+            """)
+        ]
     }
 }
 


### PR DESCRIPTION
### Problem statement:

The core of the problem is that transient builders didn't always create unique instances.

If you look at this class relationship:

```swift
class App {
    // weaver: manager = Manager
    // weaver: manager.scope = .transient

    // weaver: object1 = Object1
}

class Object1 {
    // weaver: manager <- Manager

    // weaver: object2 = Object2
}

class Object2 {
    // weaver: manager <- Manager
}

class Manager { }
```

in the existing implementation, you'd end up with these results:

- `App` -> Manager instance A
- `Object1` -> Manager instance B
- `Object2` -> Manager instance B

And the same instance (B) would be passed down from there on. 

The new implementation results in:

- `App` -> Manager instance A
- `Object1` -> Manager instance B
- `Object2` -> Manager instance C

And down the chain would create D, E, F, etc. Additionally any new calls to the builder by the same class would generate new unique instances. 


### Architectural change

The main issue is that we were storing builder object, but the first time the transient builder was fulfilled, we retained a reference to the returned object instead. 

To solve this, we now have a separate `Provider` class that holds a reference to the builders. Additionally, the `Provider` object has a `weak` reference to an `owner`.

This moves the weak referencing out of the builder itself and into the Provider. The code change also ensures that builders do not hold a reference to the parent container object. The end result is this allows us to transfer ownership of builders down the chain so that they are bound to the memory lifecycle of the children nodes.

This ultimately solves the problem of a `transient` dependency instantiating a `container` dependency that nodes down the tree expect to continue to exist. The lifecycle is no longer bound to the instantiating container, but also to children referencing it.
