### PR TITLE
Fix transient builders without requiring owner

### DIFF
--- a/Sources/WeaverCodeGen/MetaUtils.swift
+++ b/Sources/WeaverCodeGen/MetaUtils.swift
@@ -8,6 +8,10 @@
 import Foundation
 import Meta
 
+extension Reference {
+    static let provider = Reference.named("provider")
+}
+
 extension TypeIdentifier {
     
     static let mainDependencyContainer = TypeIdentifier(name: "MainDependencyContainer")
@@ -17,17 +21,18 @@ extension TypeIdentifier {
     static let abstractType = TypeIdentifier(name: "AbstractType")
     static let concreteType = TypeIdentifier(name: "ConcreteType")
     static let resolver = TypeIdentifier(name: "Resolver")
+    static let provider = TypeIdentifier(name: "Provider")
 
     static func builder(of typeID: TypeIdentifier) -> TypeIdentifier {
-        return TypeIdentifier(name: "Builder").adding(genericParameter: typeID)
+        return TypeIdentifier(name: "Provider.Builder").adding(genericParameter: typeID)
     }
 }
 
 extension Variable {
-    
+
+    static let `self` = Variable(name: "self")
     static let _self = Variable(name: "_self")
     static let __self = Variable(name: "__self")
-    static let __mainSelf = Variable(name: "__mainSelf")
     static let source = Variable(name: "source")
     static let value = Variable(name: "_value")
     static let proxySelf = Variable(name: "value")
@@ -205,5 +210,32 @@ extension String {
         guard let firstChar = _self.first else { return String() }
         _self.removeFirst()
         return prefix + firstChar.uppercased() + _self
+    }
+}
+
+// MARK: - Provider
+
+extension Reference {
+
+    static func providerFunction(name: String, reference: Reference) -> Reference {
+        return TypeIdentifier.provider.reference + .named(name) | .call(Tuple()
+            .adding(parameter: TupleParameter(value: reference))
+        )
+    }
+
+    static func valueBuilder(value: Reference) -> Reference {
+        return providerFunction(name: "valueBuilder", reference: value)
+    }
+
+    static func weakOptionalValueBuilder(value: Reference) -> Reference {
+        return providerFunction(name: "weakOptionalValueBuilder", reference: value)
+    }
+
+    static func lazyBuilder(body: FunctionBody) -> Reference {
+        return providerFunction(name: "lazyBuilder", reference: .block(body))
+    }
+
+    static func weakLazyBuilder(body: FunctionBody) -> Reference {
+        return providerFunction(name: "weakLazyBuilder", reference: .block(body))
     }
 }


### PR DESCRIPTION
This is an increment from the previous solution: https://github.com/scribd/Weaver/pull/158.

The main change here is that we remove the `owner` property from the `Provider` class.

I realized that by separating the `Provider` from `MainDependencyContainer` we had already given ourselves a way to maintain the memory graph without the weak references* (with one exception listed at the end).

Instead, we can simply hold references to the Providers inside of our blocks and then release them naturally as the retaining objects are released. The owner reference was entirely unneeded!

The one case where we will use a weak reference to the `Provider` object is in the case where the parent container has a `setter = true` dependency. In this case we need to make sure that we copy the Provider right as we instantiate the child to ensure that we're getting the proper object passed to the setter reference (this could have been set 1 or more times).

Since only `.container` objects will have a `setter = true` dependency, then we can safely use the weak reference to the Provider is this specific situation.
