### PR TITLE
Add support to reference dependencies that have parameters and are transient.

### DIFF
--- a/Sources/WeaverCodeGen/Error.swift
+++ b/Sources/WeaverCodeGen/Error.swift
@@ -72,7 +72,7 @@ enum InspectorAnalysisHistoryRecord: Error {
     case typeMismatch(Dependency, candidate: Dependency)
     case implicitDependency(Dependency, candidates: [Dependency])
     case implicitType(Dependency, candidates: [Dependency])
-    case invalidContainerScope(Dependency)
+    case invalidContainerScope(Dependency, scope: Scope)
 }
 
 // MARK: - Printables
@@ -325,8 +325,8 @@ extension InspectorAnalysisHistoryRecord: CustomStringConvertible {
             candidate.xcodeLogString(.warning, "Found candidate '\(candidate.dependencyName): \(candidate.type.description)'")
             }.joined(separator: ".\n"))
             """
-        case .invalidContainerScope(let dependency):
-            let message = "Dependency '\(dependency.dependencyName)' cannot declare parameters and be registered with a container scope. This must either have no parameters or itself be injected as a parameter to a parent depdenceny"
+        case .invalidContainerScope(let dependency, let scope):
+            let message = "Dependency '\(dependency.dependencyName)' cannot declare parameters and be registered with a \(scope) scope. This must either have no parameters or itself be injected as a parameter to a parent depdenceny"
             return dependency.fileLocation?.xcodeLogString(.error, message) ?? message
         }
     }


### PR DESCRIPTION
Add support for references to transient properties that take parameters.

E.g. a structure like this:

```swift
            final class MovieViewController {
                // weaver: movieManager = MovieManager
                // weaver: movieManager.scope = .transient

                // weaver: otherClass = OtherClass
                // weaver: otherClass.scope = .container
            }

            final class OtherClass {
                // weaver: movieManager <- MovieManager
            }

            final class MovieManager {
                // weaver: movieID <= Int
            }
```

In this case `OtherClass` should be able to inherit the transient builder for `MovieManager` since it will build a new instance every time.

This should now work correctly with the previous fix for transient objects.