### PR TITLE
Fix dependency resolver ordering

### DIFF
--- a/Sources/WeaverCodeGen/SwiftGenerator.swift
+++ b/Sources/WeaverCodeGen/SwiftGenerator.swift
@@ -340,7 +340,7 @@ private static var _dynamicResolvers = [Any]()
 private static var _dynamicResolversLock = NSRecursiveLock()
 
 fileprivate static func _popDynamicResolver<Resolver>(_ resolverType: Resolver.Type) -> Resolver {
-    guard let dynamicResolver = _dynamicResolvers.removeFirst() as? Resolver else {
+    guard let dynamicResolver = _dynamicResolvers.removeLast() as? Resolver else {
         \(TypeIdentifier.mainDependencyContainer.swiftString).fatalError()
     }
     return dynamicResolver
@@ -863,7 +863,7 @@ static func _pushDynamicResolver<Resolver>(_ resolver: Resolver) {
                         return nil
                     }
                 })
-                .adding(members: try dependencyContainer.dependencies.orderedValues.compactMap { dependency in
+                .adding(members: try dependencyContainer.dependencies.orderedValues.reversed().compactMap { dependency in
                     guard dependency.annotationStyle == .propertyWrapper else { return nil }
                     let declaration = try self.declaration(for: dependency)
                     return TypeIdentifier.mainDependencyContainer.reference + .named("_pushDynamicResolver") | .call(Tuple()
@@ -1235,7 +1235,7 @@ private extension MetaWeaverFile {
                             value: Reference.named(parameter.dependencyName)
                         )
                     })
-                    .adding(members: try dependencyContainer.dependencies.orderedValues.compactMap { dependency in
+                    .adding(members: try dependencyContainer.dependencies.orderedValues.reversed().compactMap { dependency in
                         guard dependency.annotationStyle == .propertyWrapper else { return nil }
                         let declaration = try self.declaration(for: dependency)
                         return TypeIdentifier.mainDependencyContainer.reference + .named("_pushDynamicResolver") | .call(Tuple()

--- a/Sources/WeaverCommand/Command.swift
+++ b/Sources/WeaverCommand/Command.swift
@@ -13,7 +13,7 @@ import Darwin
 import PathKit
 import Rainbow
 
-private let version = "1.1.0"
+private let version = "1.1.1"
 
 // MARK: - Linker
 


### PR DESCRIPTION
This makes a change to how we manage the `_dynamicResolvers` array.

The old code popped _from the front_:
```swift
    fileprivate static func _popDynamicResolver<Resolver>(_ resolverType: Resolver.Type) -> Resolver {
        guard let dynamicResolver = _dynamicResolvers.removeFirst() as? Resolver else {
            MainDependencyContainer.fatalError()
        }
        return dynamicResolver
    }
```

And I've updated this to pop _from the back_:
```swift
    fileprivate static func _popDynamicResolver<Resolver>(_ resolverType: Resolver.Type) -> Resolver {
        guard let dynamicResolver = _dynamicResolvers.removeLast() as? Resolver else {
            MainDependencyContainer.fatalError()
        }
        return dynamicResolver
    }
```

And to support this, I've inverted the ordering of how the dependencies are pushed.

Here's the use case of the `Repository` class being built
```swift
        _builders["repository"] = Provider.lazyBuilder(
             { (_: Optional<Provider.ParametersCopier>) -> RepositoryProtocol in
                defer { MainDependencyContainer._dynamicResolversLock.unlock() }
                MainDependencyContainer._dynamicResolversLock.lock()
                let _inputContainer = MainDependencyContainer(provider: _inputProvider)
                let __self = _inputContainer.repositoryDependencyResolver()
                return Repository(injecting: __self)
            }
        )
```

This calls the function `repositoryDependencyResolver()` which pushes the dependency resolvers. To make sure we pop these off the stack correctly, we push them on in reverse order (so the first one we attempt to access is on the end).

Here's a look at the changes to the `repositoryDependencyResolver()` function...

Old:
```swift
    private func repositoryDependencyResolver() -> RepositoryDependencyResolver {
        let _self = MainDependencyContainer()
        var _builders = Dictionary<String, Any>()
        _builders["repositoryExampleSubClass"] = repositoryExampleSubClassBuilder
        _builders["service"] = serviceBuilder
        _builders["service2"] = service2Builder
        _self.provider.addBuilders(_builders)
        MainDependencyContainer._pushDynamicResolver({ _self.service })
        MainDependencyContainer._pushDynamicResolver({ _self.service2 })
        MainDependencyContainer._pushDynamicResolver({ _self.repositoryExampleSubClass })
        return _self
    }
```

New:
```swift
    private func repositoryDependencyResolver() -> RepositoryDependencyResolver {
        let _self = MainDependencyContainer()
        var _builders = Dictionary<String, Any>()
        _builders["repositoryExampleSubClass"] = repositoryExampleSubClassBuilder
        _builders["service"] = serviceBuilder
        _builders["service2"] = service2Builder
        _self.provider.addBuilders(_builders)
        MainDependencyContainer._pushDynamicResolver({ _self.repositoryExampleSubClass })
        MainDependencyContainer._pushDynamicResolver({ _self.service2 })
        MainDependencyContainer._pushDynamicResolver({ _self.service })
        return _self
    }
```