### PR TITLE
Fix two bugs: runtime tree inspection and ignore paths.

### DIFF
--- a/Sources/WeaverCodeGen/Inspector.swift
+++ b/Sources/WeaverCodeGen/Inspector.swift
@@ -29,11 +29,18 @@ public final class Inspector {
             }
         }
 
+        try validateRuntime()
+    }
+
+    @discardableResult
+    public func validateRuntime() throws -> [TreeNode] {
+        var treeNodes: [TreeNode] = []
         for rootContainer in dependencyGraph.rootContainers {
-            if let treeInspector = RuntimeTreeInspector(rootContainer: rootContainer, dependencyGraph: dependencyGraph) {
-                try treeInspector.validate()
-            }
+            let treeInspector = RuntimeTreeInspector(rootContainer: rootContainer, dependencyGraph: dependencyGraph)
+            try treeInspector.validate()
+            treeNodes.append(treeInspector.rootNode)
         }
+        return treeNodes
     }
 }
 

--- a/Sources/WeaverCommand/Configuration.swift
+++ b/Sources/WeaverCommand/Configuration.swift
@@ -240,7 +240,8 @@ extension Configuration {
     
     func inputPaths() throws -> [Path]  {
         var inputPaths = Set<Path>()
-        
+        var fullIgnoredPaths = Set<Path>()
+
         inputPaths.formUnion(inputPathStrings
             .lazy
             .map { self.projectPath + $0 }
@@ -248,7 +249,14 @@ extension Configuration {
             .filter { $0.exists && $0.isFile && $0.extension == "swift" }
             .map { $0.absolute() })
 
-        inputPaths.subtract(try ignoredPathStrings
+        fullIgnoredPaths.formUnion(ignoredPathStrings
+            .lazy
+            .map { self.projectPath + $0 }
+            .flatMap { $0.isFile ? [$0] : self.recursivePathsByPattern(fromDirectory: $0) }
+            .filter { $0.exists && $0.isFile && $0.extension == "swift" }
+            .map { $0.absolute() })
+
+        inputPaths.subtract(try fullIgnoredPaths
             .lazy
             .map { self.projectPath + $0 }
             .flatMap { $0.isFile ? [$0] : try paths(fromDirectory: $0) }


### PR DESCRIPTION
This PR fixes two issues.

1. The runtime parse of the tree would sometimes fail if two separate abstractions were backed by the same concrete type. Example below.

```swift
    // weaver: appLifecycleEventProvider = AppLifecycleEventController <- AppLifecycleEventProviding
    // weaver: appLifecycleEventProvider.builder = { _ in AppLifecycleEventController.shared }
    // weaver: appLifecycleEventProvider.scope = .container

    // weaver: appLifecycleEventConfiguration = AppLifecycleEventController <- AppLifecycleEventConfiguring
    // weaver: appLifecycleEventConfiguration.builder = { _ in AppLifecycleEventController.shared }
    // weaver: appLifecycleEventConfiguration.scope = .container
```

2. A bug where the `ignored_paths` listed in the `.yaml` file weren't being properly filtered from the include list.